### PR TITLE
Make LLVM 3.5 version more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # LLVM
 
-LLVM bindings for the Nim language.
+LLVM bindings for the Nim language. (Currently using LLVM 3.5)
 
 ## Documentation
+
+Prequisites:
+- LLVM version 3.5 (for llvm-config-3.5)
+- libllvm (for the LLVM library)
 
 [http://FedeOmoto.github.io/llvm/](http://FedeOmoto.github.io/llvm/)

--- a/src/llvm_lib.nim
+++ b/src/llvm_lib.nim
@@ -1,21 +1,21 @@
 when not defined(static_link):
   const libname = "LLVM-3.5"
 
-{.passC: gorge("llvm-config --cflags").}
+{.passC: gorge("llvm-config-3.5 --cflags").}
 
 when defined(dynamic_link) or defined(static_link):
-  const ldflags = gorge("llvm-config --ldflags")
+  const ldflags = gorge("llvm-config-3.5 --ldflags")
   {.pragma: libllvm, cdecl.}
   when defined(dynamic_link): # Dynamic linking
     {.passL: ldflags & "-l" & libname.}
   else: # Static linking
-    {.passL: gorge("llvm-config --system-libs") & "-lstdc++ " & ldflags &
-     gorge("llvm-config --libs").}
+    {.passL: gorge("llvm-config-3.5 --system-libs") & "-lstdc++ " & ldflags &
+     gorge("llvm-config-3.5 --libs").}
 else: # Dynamic loading
   when defined(windows): 
     const dllname = libname & ".dll"
   elif defined(macosx):
-    const dllname = "lib" & libname & "(|.0).dylib"
+    const dllname = "lib" & libname & "(|.2).(0|1).dylib"
   else: 
-    const dllname = "lib" & libname & "(|.0).so"
+    const dllname = "lib" & libname & "(|.2).so.(0|1)"
   {.pragma: libllvm, cdecl, dynlib: dllname.}

--- a/src/llvm_lto.nim
+++ b/src/llvm_lto.nim
@@ -4,17 +4,17 @@
 
 const libname = "LTO"
 
-{.passC: gorge("llvm-config --cflags").}
+{.passC: gorge("llvm-config-3.5 --cflags").}
 
 when defined(dynamic_link) or defined(static_link):
-  const ldflags = gorge("llvm-config --ldflags")
+  const ldflags = gorge("llvm-config-3.5 --ldflags")
   {.pragma: liblto, cdecl.}
   when defined(dynamic_link): # Dynamic linking
     {.passL: ldflags & "-l" & libname.}
   else: # Static linking
-    const libdir = gorge("llvm-config --libdir")
-    {.passL: gorge("llvm-config --system-libs") & "-lstdc++ " & ldflags &
-     libdir & "/lib" & libname & ".a " & gorge("llvm-config --libs").}
+    const libdir = gorge("llvm-config-3.5 --libdir")
+    {.passL: gorge("llvm-config-3.5 --system-libs") & "-lstdc++ " & ldflags &
+     libdir & "/lib" & libname & ".a " & gorge("llvm-config-3.5 --libs").}
 else: # Dynamic loading
   when defined(windows):
     const dllname =  libname & ".dll"

--- a/src/llvm_target.nim
+++ b/src/llvm_target.nim
@@ -13,7 +13,7 @@ proc defPath(): string {.compileTime.} =
   result = ".."
   for i in 3..currentSourcePath.count("/"):
     result &= "/.."
-  result &= gorge("llvm-config --includedir") & "/llvm/Config/"
+  result &= gorge("llvm-config-3.5 --includedir") & "/llvm/Config/"
 
 const DefPath = defPath()
 
@@ -40,7 +40,7 @@ macro targetsFor(suffix: string): stmt =
 
 # Target information
 
-const Targets* = gorge("llvm-config --targets-built").strip.split(' ')
+const Targets* = gorge("llvm-config-3.5 --targets-built").strip.split(' ')
 
 targetsFor("AsmPrinter")
 targetsFor("AsmParser")


### PR DESCRIPTION
- llvm-config -> llvm-config-3.5, since we're already depending explicitly
  on llvm v 3.5
- Make libllvm3.5.so versions less strict (include libLLVM-3.5.2.so,
  since that is the version included in debian sid for libllvm-3.5)

Was able to get working on Debian sid with these changes (compiled examples), not sure how well this generalizes.
